### PR TITLE
Use multiplatform implementation for concurrency

### DIFF
--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -1,11 +1,13 @@
 [versions]
 
 assertk = "0.28.1"
+atomicfu = "0.25.0"
 dokkaPlugin = "1.9.20"
 kotlin = "2.0.0"
 kotlinxJson = "1.6.3"
 ktlintPlugin = "12.1.1"
 ksoup="0.1.6-alpha1"
+statelyConcurrency = "2.0.0"
 
 [libraries]
 # kotlin
@@ -13,12 +15,14 @@ kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxJson" }
 ksoup = { module = "com.fleeksoft.ksoup:ksoup", version.ref = "ksoup" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
+stately-concurrent-collections = { module = "co.touchlab:stately-concurrent-collections", version.ref = "statelyConcurrency" }
 
 # test
 test-assertk = { module = "com.willowtreeapps.assertk:assertk", version.ref = "assertk" }
 
 [plugins]
 kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
+kotlin-atomicfu = { id = "org.jetbrains.kotlinx.atomicfu", version.ref = "atomicfu" }
 kotlinCocoapods = { id = "org.jetbrains.kotlin.native.cocoapods", version.ref = "kotlin" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlintPlugin" }

--- a/model/build.gradle.kts
+++ b/model/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
   alias(libs.plugins.kotlin.jvm)
+  alias(libs.plugins.kotlin.atomicfu)
   alias(libs.plugins.ktlint)
   alias(libs.plugins.dokka)
   id("maven-publish")
@@ -18,12 +19,12 @@ java {
 dependencies {
   implementation(libs.kotlin.stdlib)
   implementation(libs.kotlinx.serialization.json)
+  implementation(libs.stately.concurrent.collections)
   implementation(project(":util"))
   api(libs.ksoup)
   testImplementation(project(":test-builder"))
   testImplementation(kotlin("test"))
   testImplementation(libs.test.assertk)
-
 }
 
 description = "prosemirror-model"

--- a/model/config/ktlint/baseline.xml
+++ b/model/config/ktlint/baseline.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <baseline version="1.0">
-    <file name="build.gradle.kts">
-        <error line="26" column="1" source="standard:no-blank-line-before-rbrace" />
-    </file>
     <file name="src/main/kotlin/com/atlassian/prosemirror/model/CompareDeep.kt">
         <error line="3" column="17" source="standard:function-signature" />
         <error line="3" column="25" source="standard:function-signature" />
@@ -348,22 +345,21 @@
         <error line="253" column="61" source="standard:function-signature" />
     </file>
     <file name="src/main/kotlin/com/atlassian/prosemirror/model/ResolvedPos.kt">
-        <error line="127" column="20" source="standard:function-signature" />
-        <error line="127" column="32" source="standard:function-signature" />
-        <error line="127" column="50" source="standard:function-signature" />
-        <error line="209" column="20" source="standard:function-signature" />
-        <error line="209" column="47" source="standard:function-signature" />
-        <error line="209" column="86" source="standard:function-signature" />
-        <error line="248" column="30" source="standard:function-signature" />
-        <error line="248" column="41" source="standard:function-signature" />
-        <error line="248" column="49" source="standard:function-signature" />
-        <error line="271" column="36" source="standard:function-signature" />
-        <error line="271" column="47" source="standard:function-signature" />
-        <error line="271" column="55" source="standard:function-signature" />
-        <error line="296" column="1" source="standard:no-blank-line-in-list" />
+        <error line="129" column="20" source="standard:function-signature" />
+        <error line="129" column="32" source="standard:function-signature" />
+        <error line="129" column="50" source="standard:function-signature" />
+        <error line="211" column="20" source="standard:function-signature" />
+        <error line="211" column="47" source="standard:function-signature" />
+        <error line="211" column="86" source="standard:function-signature" />
+        <error line="250" column="30" source="standard:function-signature" />
+        <error line="250" column="41" source="standard:function-signature" />
+        <error line="250" column="49" source="standard:function-signature" />
+        <error line="273" column="36" source="standard:function-signature" />
+        <error line="273" column="47" source="standard:function-signature" />
+        <error line="273" column="55" source="standard:function-signature" />
+        <error line="299" column="1" source="standard:no-blank-line-in-list" />
     </file>
     <file name="src/main/kotlin/com/atlassian/prosemirror/model/Schema.kt">
-        <error line="5" column="1" source="standard:import-ordering" />
         <error line="18" column="18" source="standard:function-signature" />
         <error line="18" column="49" source="standard:function-signature" />
         <error line="18" column="83" source="standard:function-signature" />
@@ -425,65 +421,65 @@
         <error line="427" column="1" source="standard:no-blank-line-in-list" />
         <error line="431" column="1" source="standard:no-blank-line-in-list" />
         <error line="435" column="1" source="standard:no-blank-line-in-list" />
-        <error line="638" column="33" source="standard:multiline-expression-wrapping" />
-        <error line="642" column="28" source="standard:multiline-expression-wrapping" />
-        <error line="651" column="29" source="standard:multiline-expression-wrapping" />
-        <error line="676" column="14" source="standard:function-signature" />
-        <error line="676" column="30" source="standard:function-signature" />
-        <error line="676" column="52" source="standard:function-signature" />
-        <error line="676" column="72" source="standard:function-signature" />
-        <error line="676" column="90" source="standard:function-signature" />
-        <error line="684" column="14" source="standard:function-signature" />
-        <error line="684" column="30" source="standard:function-signature" />
-        <error line="684" column="52" source="standard:function-signature" />
-        <error line="684" column="68" source="standard:function-signature" />
-        <error line="684" column="86" source="standard:function-signature" />
-        <error line="692" column="14" source="standard:function-signature" />
-        <error line="692" column="30" source="standard:function-signature" />
-        <error line="692" column="52" source="standard:function-signature" />
-        <error line="692" column="74" source="standard:function-signature" />
-        <error line="692" column="92" source="standard:function-signature" />
-        <error line="700" column="29" source="standard:function-signature" />
+        <error line="635" column="33" source="standard:multiline-expression-wrapping" />
+        <error line="639" column="28" source="standard:multiline-expression-wrapping" />
+        <error line="648" column="29" source="standard:multiline-expression-wrapping" />
+        <error line="673" column="14" source="standard:function-signature" />
+        <error line="673" column="30" source="standard:function-signature" />
+        <error line="673" column="52" source="standard:function-signature" />
+        <error line="673" column="72" source="standard:function-signature" />
+        <error line="673" column="90" source="standard:function-signature" />
+        <error line="681" column="14" source="standard:function-signature" />
+        <error line="681" column="30" source="standard:function-signature" />
+        <error line="681" column="52" source="standard:function-signature" />
+        <error line="681" column="68" source="standard:function-signature" />
+        <error line="681" column="86" source="standard:function-signature" />
+        <error line="689" column="14" source="standard:function-signature" />
+        <error line="689" column="30" source="standard:function-signature" />
+        <error line="689" column="52" source="standard:function-signature" />
+        <error line="689" column="74" source="standard:function-signature" />
+        <error line="689" column="92" source="standard:function-signature" />
+        <error line="697" column="29" source="standard:function-signature" />
+        <error line="700" column="14" source="standard:function-signature" />
+        <error line="700" column="28" source="standard:function-signature" />
+        <error line="700" column="48" source="standard:function-signature" />
+        <error line="700" column="51" source="standard:function-signature" />
         <error line="703" column="14" source="standard:function-signature" />
         <error line="703" column="28" source="standard:function-signature" />
-        <error line="703" column="48" source="standard:function-signature" />
-        <error line="703" column="51" source="standard:function-signature" />
+        <error line="703" column="50" source="standard:function-signature" />
+        <error line="703" column="70" source="standard:function-signature" />
+        <error line="703" column="95" source="standard:function-signature" />
+        <error line="703" column="98" source="standard:function-signature" />
         <error line="706" column="14" source="standard:function-signature" />
         <error line="706" column="28" source="standard:function-signature" />
         <error line="706" column="50" source="standard:function-signature" />
-        <error line="706" column="70" source="standard:function-signature" />
-        <error line="706" column="95" source="standard:function-signature" />
-        <error line="706" column="98" source="standard:function-signature" />
+        <error line="706" column="66" source="standard:function-signature" />
+        <error line="706" column="91" source="standard:function-signature" />
+        <error line="706" column="94" source="standard:function-signature" />
         <error line="709" column="14" source="standard:function-signature" />
         <error line="709" column="28" source="standard:function-signature" />
         <error line="709" column="50" source="standard:function-signature" />
-        <error line="709" column="66" source="standard:function-signature" />
-        <error line="709" column="91" source="standard:function-signature" />
-        <error line="709" column="94" source="standard:function-signature" />
-        <error line="712" column="14" source="standard:function-signature" />
-        <error line="712" column="28" source="standard:function-signature" />
-        <error line="712" column="50" source="standard:function-signature" />
-        <error line="712" column="72" source="standard:function-signature" />
-        <error line="712" column="97" source="standard:function-signature" />
-        <error line="712" column="100" source="standard:function-signature" />
-        <error line="716" column="14" source="standard:function-signature" />
-        <error line="716" column="28" source="standard:function-signature" />
-        <error line="716" column="53" source="standard:function-signature" />
-        <error line="722" column="14" source="standard:function-signature" />
-        <error line="722" column="28" source="standard:function-signature" />
-        <error line="722" column="48" source="standard:function-signature" />
-        <error line="727" column="14" source="standard:function-signature" />
-        <error line="727" column="30" source="standard:function-signature" />
-        <error line="727" column="50" source="standard:function-signature" />
-        <error line="732" column="22" source="standard:function-signature" />
-        <error line="732" column="41" source="standard:function-signature" />
-        <error line="732" column="64" source="standard:function-signature" />
-        <error line="737" column="22" source="standard:function-signature" />
-        <error line="737" column="41" source="standard:function-signature" />
-        <error line="737" column="64" source="standard:function-signature" />
-        <error line="747" column="17" source="standard:function-signature" />
-        <error line="747" column="33" source="standard:function-signature" />
-        <error line="747" column="52" source="standard:function-signature" />
+        <error line="709" column="72" source="standard:function-signature" />
+        <error line="709" column="97" source="standard:function-signature" />
+        <error line="709" column="100" source="standard:function-signature" />
+        <error line="713" column="14" source="standard:function-signature" />
+        <error line="713" column="28" source="standard:function-signature" />
+        <error line="713" column="53" source="standard:function-signature" />
+        <error line="719" column="14" source="standard:function-signature" />
+        <error line="719" column="28" source="standard:function-signature" />
+        <error line="719" column="48" source="standard:function-signature" />
+        <error line="724" column="14" source="standard:function-signature" />
+        <error line="724" column="30" source="standard:function-signature" />
+        <error line="724" column="50" source="standard:function-signature" />
+        <error line="729" column="22" source="standard:function-signature" />
+        <error line="729" column="41" source="standard:function-signature" />
+        <error line="729" column="64" source="standard:function-signature" />
+        <error line="734" column="22" source="standard:function-signature" />
+        <error line="734" column="41" source="standard:function-signature" />
+        <error line="734" column="64" source="standard:function-signature" />
+        <error line="744" column="17" source="standard:function-signature" />
+        <error line="744" column="33" source="standard:function-signature" />
+        <error line="744" column="52" source="standard:function-signature" />
     </file>
     <file name="src/main/kotlin/com/atlassian/prosemirror/model/ToDom.kt">
         <error line="27" column="5" source="standard:blank-line-before-declaration" />

--- a/model/src/main/kotlin/com/atlassian/prosemirror/model/Schema.kt
+++ b/model/src/main/kotlin/com/atlassian/prosemirror/model/Schema.kt
@@ -2,10 +2,10 @@
 
 package com.atlassian.prosemirror.model
 
+import co.touchlab.stately.collections.ConcurrentMutableList
 import com.atlassian.prosemirror.util.verbose
+import kotlinx.atomicfu.atomic
 import kotlinx.serialization.json.JsonObject
-import java.util.concurrent.CopyOnWriteArrayList
-import java.util.concurrent.atomic.AtomicInteger
 
 // An object holding the attributes of a node.
 typealias Attrs = Map<String, Any?>
@@ -609,17 +609,14 @@ class Schema {
 
     /**
      * From some testing on mix-contents.json (will differ based on document etc.);
-     * Initial Render: 3:1 interating (reads) vs writing
+     * Initial Render: 3:1 iterating (reads) vs writing
      * Selection: ~10:1
      * Typing: ~5:1
-     *
-     * Therefore, CopyOnWriteArrayList is probably preferable to synchronizing out traversals (w/synchronizedList),
-     * despite the penalty of having to copy on write (the size is only 12 anyway).
      */
-    val resolveCache = CopyOnWriteArrayList<ResolvedPos>()
+    val resolveCache = ConcurrentMutableList<ResolvedPos>()
 
     @Suppress("MayBeConst")
-    var resolveCachePos = AtomicInteger(0)
+    val resolveCachePos = atomic(0)
 
     // Construct a schema from a schema [specification](#model.SchemaSpec).
     constructor(spec: SchemaSpec) {


### PR DESCRIPTION
There is no `java.util.concurrent` for multiplatform, so had to use alternatives.