### PR TITLE
Bug fix in TypeScript translation

### DIFF
--- a/model/src/commonMain/kotlin/com/atlassian/prosemirror/model/Schema.kt
+++ b/model/src/commonMain/kotlin/com/atlassian/prosemirror/model/Schema.kt
@@ -254,7 +254,7 @@ class NodeType internal constructor(
         var copy: MutableList<Mark>? = null
         marks.forEachIndexed { i, mark ->
             if (!this.allowsMarkType(mark.type)) {
-                if (copy == null) copy = marks.slice(0..i).toMutableList()
+                if (copy == null) copy = marks.slice(0..<i).toMutableList()
             } else {
                 copy?.add(mark)
             }


### PR DESCRIPTION
This was converted from TS incorrectly, the TS is: if (!copy) copy = marks.slice(0, i) and the docs for slice is:
![Screenshot 2024-09-27 at 3 05 38 PM](https://github.com/user-attachments/assets/54442bc9-93da-498b-a675-cd37db998a69)
