### PR TITLE
Bump prosemirror-test-builder, prosemirror-schema-basic and prosemirror-schema-list

### DIFF
--- a/model/src/commonTest/kotlin/com/atlassian/prosemirror/model/DomTest.kt
+++ b/model/src/commonTest/kotlin/com/atlassian/prosemirror/model/DomTest.kt
@@ -493,35 +493,58 @@ class DomTest {
             doc { p { strong { +"Hello" } } }
         )
     }
+
+    @Test
+    fun `allows clearing of pending marks`() {
+        recover(
+            "<blockquote style='font-style: italic'><p style='font-style: normal'>One</p><p>Two</p></blockquote>",
+            doc { blockquote { p { +"One" } + p { em { +"Two" } } } }
+        )
+    }
+
+    @Test
+    fun `allows clearing of active marks`() {
+        recover(
+            "<ul><li style='font-style:italic'><p><span>Foo</span><span></span>" +
+                "<span style='font-style:normal'>Bar</span></p></li></ul>",
+            doc { ul { li { p { em { +"Foo" } + "Bar" } } } }
+        )
+    }
+
+    @Test
+    fun `ignores unknown inline tags`() {
+        recover(
+            "<p><u>a</u>bc</p>",
+            doc { p { +"abc" } }
+        )
+    }
+
+    @Test
+    fun `keeps applying a mark for the all of the node's content`() {
+        recover(
+            "<p><strong><span>xx</span>bar</strong></p>",
+            doc { p { strong { +"xxbar" } } }
+        )
+    }
+
+    @Test
+    fun `doesn't ignore whitespace-only nodes in preserveWhitespace full mode`() {
+        recover(
+            "<span> </span>x",
+            doc { p { +" x" } },
+            options = ParseOptionsImpl(preserveWhitespace = PreserveWhitespace.FULL)
+        )
+    }
+
+    @Test
+    fun `closes block with inline content on seeing block-level children`() {
+        recover(
+            "<div><br><div>CCC</div><div>DDD</div><br></div>",
+            doc { p { br {} } + p { +"CCC" } + p { +"DDD" } + p { br {} } }
+        )
+    }
 }
 
-//        it("allows clearing of pending marks",
-//            recover("<blockquote style='font-style: italic'><p style='font-style: normal'>One</p><p>Two</p></blockquote",
-//                doc(blockquote(p("One"), p(em("Two"))))))
-//
-//        it("allo clearing of active marks",
-//            recover("<ul><li style='font-style:italic'><p><span>Foo</span><span></span>" +
-//                "<span style='font-style:normal'>Bar</span></p></li></ul>",
-//                doc(ul(li(p(em("Foo"), "Bar"))))))
-//
-//        it("ignores unknown inline tags",
-//            recover("<p><u>a</u>bc</p>",
-//                doc(p("abc"))))
-//
-//        it("can add marks specified before their parent node is opened",
-//            recover("<em>hi</em> you",
-//                doc(p(em("hi"), " you"))))
-//
-//        it("keeps applying a mark for the all of the node's content",
-//            recover("<p><strong><span>xx</span>bar</strong></p>",
-//                doc(p(strong("xxbar")))))
-//
-//        it("doesn't ignore whitespace-only nodes in preserveWhitespace full mode",
-//            recover("<span> </span>x", doc(p(" x")), {preserveWhitespace: "full"}))
-//
-//        it("closes block with inline content on seeing block-level children",
-//            recover("<div><br><div>CCC</div><div>DDD</div><br></div>",
-//                doc(p(br()), p("CCC"), p("DDD"), p(br()))))
 //
 //        function parse(html: string, options: ParseOptions, doc: PMNode) {
 //        return () => {

--- a/test-builder/README.md
+++ b/test-builder/README.md
@@ -89,3 +89,11 @@ Check the latest package at Maven central on: https://packages.atlassian.com/mav
 ```kotlin
 implementation("com.atlassian.prosemirror:test-builder:1.0.2")
 ```
+### Versioning
+- Implemented changes to match version:
+  - [1.1.1](https://github.com/ProseMirror/prosemirror-test-builder/releases/tag/1.1.1)
+    of prosemirror-test-builder
+  - [1.2.3](https://github.com/ProseMirror/prosemirror-schema-basic/releases/tag/1.2.3)
+    of prosemirror-schema-basic
+  - [1.4.1](https://github.com/ProseMirror/prosemirror-schema-list/releases/tag/1.4.1)
+    of prosemirror-schema-list

--- a/test-builder/config/ktlint/baseline.xml
+++ b/test-builder/config/ktlint/baseline.xml
@@ -109,14 +109,14 @@
         <error line="185" column="1" source="standard:no-blank-line-in-list" />
         <error line="188" column="13" source="standard:multiline-expression-wrapping" />
         <error line="189" column="20" source="standard:multiline-expression-wrapping" />
-        <error line="196" column="1" source="standard:no-blank-line-in-list" />
-        <error line="198" column="17" source="standard:multiline-expression-wrapping" />
-        <error line="199" column="20" source="standard:multiline-expression-wrapping" />
-        <error line="214" column="1" source="standard:no-blank-line-in-list" />
-        <error line="216" column="15" source="standard:multiline-expression-wrapping" />
+        <error line="199" column="1" source="standard:no-blank-line-in-list" />
+        <error line="201" column="17" source="standard:multiline-expression-wrapping" />
+        <error line="202" column="20" source="standard:multiline-expression-wrapping" />
         <error line="220" column="1" source="standard:no-blank-line-in-list" />
-        <error line="221" column="17" source="standard:multiline-expression-wrapping" />
-        <error line="225" column="20" source="standard:multiline-expression-wrapping" />
+        <error line="222" column="15" source="standard:multiline-expression-wrapping" />
+        <error line="226" column="1" source="standard:no-blank-line-in-list" />
+        <error line="227" column="17" source="standard:multiline-expression-wrapping" />
+        <error line="231" column="20" source="standard:multiline-expression-wrapping" />
     </file>
     <file name="src/commonMain/kotlin/com/atlassian/prosemirror/testbuilder/SchemaLists.kt">
         <error line="17" column="19" source="standard:multiline-expression-wrapping" />

--- a/test-builder/src/commonMain/kotlin/com/atlassian/prosemirror/testbuilder/SchemaBasic.kt
+++ b/test-builder/src/commonMain/kotlin/com/atlassian/prosemirror/testbuilder/SchemaBasic.kt
@@ -64,7 +64,7 @@ val nodes = mapOf<String, NodeSpec>(
     // A heading textblock, with a `level` attribute that should hold the number 1 to 6. Parsed and
     // serialized as `<h1>` to `<h6>` elements.
     "heading" to NodeSpecImpl(
-        attrs = mutableMapOf("level" to AttributeSpecImpl(default = 1)),
+        attrs = mutableMapOf("level" to AttributeSpecImpl(default = 1, validateString = "Int")),
         content = "inline*",
         group = "block",
         defining = true,
@@ -103,9 +103,9 @@ val nodes = mapOf<String, NodeSpec>(
     "image" to NodeSpecImpl(
         inline = true,
         attrs = mutableMapOf(
-            "src" to AttributeSpecImpl(),
-            "alt" to AttributeSpecImpl(default = null),
-            "title" to AttributeSpecImpl(default = null)
+            "src" to AttributeSpecImpl(default = "", validateString = "String"),
+            "alt" to AttributeSpecImpl(default = null, validateString = "String|null"),
+            "title" to AttributeSpecImpl(default = null, validateString = "String|null")
         ),
         group = "inline",
         draggable = true,
@@ -155,8 +155,8 @@ val marks = mapOf<String, MarkSpec>(
     // parsed as an `<a>` element.
     "link" to MarkSpecImpl(
         attrs = mutableMapOf<String, AttributeSpec>(
-            "href" to AttributeSpecImpl(),
-            "title" to AttributeSpecImpl(default = null)
+            "href" to AttributeSpecImpl(default = "", validateString = "String"),
+            "title" to AttributeSpecImpl(default = null, validateString = "String|null")
         ),
         inclusive = false,
         parseDOM = listOf(
@@ -189,7 +189,10 @@ val marks = mapOf<String, MarkSpec>(
         parseDOM = listOf(
             TagParseRuleImpl(tag = "i"),
             TagParseRuleImpl(tag = "em"),
-            StyleParseRuleImpl(style = "font-style=italic")
+            StyleParseRuleImpl(style = "font-style=italic"),
+            StyleParseRuleImpl(style = "font-style=normal", clearMark = { m ->
+                m.type.name == "em"
+            })
         ),
         toDOM = { _, _ -> emDOM }
     ),
@@ -203,6 +206,9 @@ val marks = mapOf<String, MarkSpec>(
             // tags with a font-weight normal.
             TagParseRuleImpl(tag = "b", getNodeAttrs = { node ->
                 ParseRuleMatch(null, node.styles()?.get("font-weight") != "normal")
+            }),
+            StyleParseRuleImpl(style = "font-weight=400", clearMark = { m ->
+                m.type.name == "strong"
             }),
             StyleParseRuleImpl(style = "font-weight", getStyleAttrs = { value ->
                 val regex = "^bold(er)?|[5-9]\\d{2,}".toRegex()

--- a/test-builder/src/commonMain/kotlin/com/atlassian/prosemirror/testbuilder/SchemaLists.kt
+++ b/test-builder/src/commonMain/kotlin/com/atlassian/prosemirror/testbuilder/SchemaLists.kt
@@ -15,7 +15,7 @@ val liDOM: DOMOutputSpec = DOMOutputSpec.ArrayDOMOutputSpec(listOf("li", 0))
 // the number at which the list starts counting, and defaults to 1. Represented as an `<ol>`
 // element.
 val orderedList = NodeSpecImpl(
-    attrs = mapOf("order" to AttributeSpecImpl(default = 1)),
+    attrs = mapOf("order" to AttributeSpecImpl(default = 1, validateString = "Int|null")),
     parseDOM = listOf(
         TagParseRuleImpl(tag = "ol", getNodeAttrs = { dom ->
             val start = if (dom.hasAttr("start")) {

--- a/test-builder/src/commonMain/kotlin/com/atlassian/prosemirror/testbuilder/build.ts
+++ b/test-builder/src/commonMain/kotlin/com/atlassian/prosemirror/testbuilder/build.ts
@@ -65,12 +65,22 @@ function takeAttrs(attrs: Attrs | null, args: [a?: Attrs | ChildSpec, ...b: Chil
   return result
 }
 
-export type NodeBuilder = (attrsOrFirstChild?: Attrs | ChildSpec, ...children: ChildSpec[]) => Node
+export type NodeBuilder = (attrsOrFirstChild?: Attrs | ChildSpec, ...children: ChildSpec[]) => Node & {tag: Tags}
 export type MarkBuilder = (attrsOrFirstChild?: Attrs | ChildSpec, ...children: ChildSpec[]) => ChildSpec
+
+type Builders<S extends Schema> = {
+  schema: S;
+} & {
+  [key in keyof S['nodes']]: NodeBuilder
+} & {
+  [key in keyof S['marks']]: MarkBuilder
+} & {
+  [name: string]: NodeBuilder | MarkBuilder
+}
 
 /// Create a builder function for nodes with content.
 function block(type: NodeType, attrs: Attrs | null = null): NodeBuilder {
-  let result: NodeBuilder = function(...args) {
+  let result = function(...args: any[]) {
     let myAttrs = takeAttrs(attrs, args)
     let {nodes, tag} = flatten(type.schema, args as ChildSpec[], id)
     let node = type.create(myAttrs, nodes)
@@ -78,7 +88,7 @@ function block(type: NodeType, attrs: Attrs | null = null): NodeBuilder {
     return node
   }
   if (type.isLeaf) try { (result as any).flat = [type.create(attrs)] } catch(_) {}
-  return result
+  return result as NodeBuilder
 }
 
 // Create a builder function for marks.
@@ -93,7 +103,7 @@ function mark(type: MarkType, attrs: Attrs | null): MarkBuilder {
   }
 }
 
-export function builders(schema: Schema, names?: {[name: string]: Attrs}) {
+export function builders<Nodes extends string = any, Marks extends string = any>(schema: Schema<Nodes, Marks>, names?: {[name: string]: Attrs}) {
   let result = {schema}
   for (let name in schema.nodes) (result as any)[name] = block(schema.nodes[name], {})
   for (let name in schema.marks) (result as any)[name] = mark(schema.marks[name], {})
@@ -103,5 +113,5 @@ export function builders(schema: Schema, names?: {[name: string]: Attrs}) {
     if (type = schema.nodes[typeName]) (result as any)[name] = block(type, value)
     else if (type = schema.marks[typeName]) (result as any)[name] = mark(type, value)
   }
-  return result
+  return result as Builders<Schema<Nodes, Marks>>
 }

--- a/test-builder/src/commonMain/kotlin/com/atlassian/prosemirror/testbuilder/schema-basic.ts
+++ b/test-builder/src/commonMain/kotlin/com/atlassian/prosemirror/testbuilder/schema-basic.ts
@@ -40,7 +40,7 @@ export const nodes = {
   /// should hold the number 1 to 6. Parsed and serialized as `<h1>` to
   /// `<h6>` elements.
   heading: {
-    attrs: {level: {default: 1}},
+    attrs: {level: {default: 1, validate: "number"}},
     content: "inline*",
     group: "block",
     defining: true,
@@ -77,9 +77,9 @@ export const nodes = {
   image: {
     inline: true,
     attrs: {
-      src: {},
-      alt: {default: null},
-      title: {default: null}
+      src: {validate: "string"},
+      alt: {default: null, validate: "string|null"},
+      title: {default: null, validate: "string|null"}
     },
     group: "inline",
     draggable: true,
@@ -112,8 +112,8 @@ export const marks = {
   /// element.
   link: {
     attrs: {
-      href: {},
-      title: {default: null}
+      href: {validate: "string"},
+      title: {default: null, validate: "string|null"}
     },
     inclusive: false,
     parseDOM: [{tag: "a[href]", getAttrs(dom: HTMLElement) {
@@ -125,19 +125,26 @@ export const marks = {
   /// An emphasis mark. Rendered as an `<em>` element. Has parse rules
   /// that also match `<i>` and `font-style: italic`.
   em: {
-    parseDOM: [{tag: "i"}, {tag: "em"}, {style: "font-style=italic"}],
+    parseDOM: [
+      {tag: "i"}, {tag: "em"},
+      {style: "font-style=italic"},
+      {style: "font-style=normal", clearMark: m => m.type.name == "em"}
+    ],
     toDOM() { return emDOM }
   } as MarkSpec,
 
   /// A strong mark. Rendered as `<strong>`, parse rules also match
   /// `<b>` and `font-weight: bold`.
   strong: {
-    parseDOM: [{tag: "strong"},
-               // This works around a Google Docs misbehavior where
-               // pasted content will be inexplicably wrapped in `<b>`
-               // tags with a font-weight normal.
-               {tag: "b", getAttrs: (node: HTMLElement) => node.style.fontWeight != "normal" && null},
-               {style: "font-weight", getAttrs: (value: string) => /^(bold(er)?|[5-9]\d{2,})$/.test(value) && null}],
+    parseDOM: [
+      {tag: "strong"},
+      // This works around a Google Docs misbehavior where
+      // pasted content will be inexplicably wrapped in `<b>`
+      // tags with a font-weight normal.
+      {tag: "b", getAttrs: (node: HTMLElement) => node.style.fontWeight != "normal" && null},
+      {style: "font-weight=400", clearMark: m => m.type.name == "strong"},
+      {style: "font-weight", getAttrs: (value: string) => /^(bold(er)?|[5-9]\d{2,})$/.test(value) && null},
+    ],
     toDOM() { return strongDOM }
   } as MarkSpec,
 

--- a/test-builder/src/commonMain/kotlin/com/atlassian/prosemirror/testbuilder/schema-list.ts
+++ b/test-builder/src/commonMain/kotlin/com/atlassian/prosemirror/testbuilder/schema-list.ts
@@ -10,7 +10,7 @@ const olDOM: DOMOutputSpec = ["ol", 0], ulDOM: DOMOutputSpec = ["ul", 0], liDOM:
 /// starts counting, and defaults to 1. Represented as an `<ol>`
 /// element.
 export const orderedList = {
-  attrs: {order: {default: 1}},
+  attrs: {order: {default: 1, validate: "number"}},
   parseDOM: [{tag: "ol", getAttrs(dom: HTMLElement) {
     return {order: dom.hasAttribute("start") ? +dom.getAttribute("start")! : 1}
   }}],
@@ -152,6 +152,19 @@ export function splitListItem(itemType: NodeType, itemAttrs?: Attrs): Command {
     if (!canSplit(tr.doc, $from.pos, 2, types)) return false
     if (dispatch) dispatch(tr.split($from.pos, 2, types).scrollIntoView())
     return true
+  }
+}
+
+/// Acts like [`splitListItem`](#schema-list.splitListItem), but
+/// without resetting the set of active marks at the cursor.
+export function splitListItemKeepMarks(itemType: NodeType, itemAttrs?: Attrs): Command {
+  let split = splitListItem(itemType, itemAttrs)
+  return (state, dispatch) => {
+    return split(state, dispatch && (tr => {
+      let marks = state.storedMarks || (state.selection.$to.parentOffset && state.selection.$from.marks())
+      if (marks) tr.ensureMarks(marks)
+      dispatch(tr)
+    }))
   }
 }
 


### PR DESCRIPTION
Bumping the test modules because some of the new tests depend on it.
There are lots more tests to convert, but I've just converted a few more in this PR to make sure that we have what we need in the test modules.