### PR TITLE
Changing the way we publish releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,9 @@ name: Publish to artifactory on release branch
 
 on:
   push:
-    branches: [ "release" ]
+    # Sequence of patterns matched against refs/tags
+    tags:
+      - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
 
 jobs:
   build:
@@ -33,6 +35,6 @@ jobs:
         with:
           output-modes: environment
 
-      # Publishes to Artifactory only on push to the "release" branch.
+      # Publishes to Artifactory only when a tag is pushed
       - name: "Publish"
         run: ./gradlew assemble --no-configuration-cache && ./gradlew publish --no-configuration-cache --stacktrace

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,3 +16,9 @@ Prior to accepting your contributions we ask that you please follow the appropri
 
 * [CLA for corporate contributors](https://opensource.atlassian.com/corporate)
 * [CLA for individuals](https://opensource.atlassian.com/individual)
+
+## Releases
+To create a release, follow these steps:
+1. Update the version in the `build.gradle.kts` file.
+2. Create a PR with these changes, targeting the `main` branch.
+3. Once the PR is merged, create a new tag with the format `v*` e.g. `v1.1.0`. The CI/CD pipeline will create a release and publish it to Artifactory.


### PR DESCRIPTION
See CONTRIBUTING.md for details.
Merging into and tagging the `release` branch is now deprecated. We will be tagging the `main` branch with releases