### PR TITLE
Cleanup readme files

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,25 @@ Java/Kotlin implementation of [Prosemirror](https://prosemirror.net/)
 
 Contributions to prosemirror-kotlin are welcome! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for details.
 
+## Maven / Gradle dependency
+Add prosemirror-kotlin dependencies using prosemirror.<moduleIdentifier> in place of the normal artifact specifier.
+
+Check the latest packages at Maven central on: https://packages.atlassian.com/maven-central/com/atlassian/prosemirror/<moduleIdentifier>.
+
+### Maven:
+```xml
+<dependency>
+    <groupId>com.atlassian.prosemirror</groupId>
+    <artifactId>{moduleIdentifier}</artifactId>
+    <version>{latest}</version>
+</dependency>
+```
+
+### Gradle:
+```kotlin
+implementation("com.atlassian.prosemirror:{moduleIdentifier}:{latest}") // this version number should be updated to update the version of prosemirror-kotlin
+```
+
 ## License
 
 Copyright (c) 2024 Atlassian and others.

--- a/collab/README.md
+++ b/collab/README.md
@@ -1,21 +1,3 @@
 This module implements an API into which a communication channel for
 collaborative editing can be hooked. See
 [the guide](/docs/guide/#collab) for more details and an example.
-
-## Maven / Gradle dependency
-
-Check the latest package at Maven central on: https://packages.atlassian.com/maven-central/com/atlassian/prosemirror/collab.
-
-### Maven:
-```xml
-<dependency>
-    <groupId>com.atlassian.prosemirror</groupId>
-    <artifactId>collab</artifactId>
-    <version>1.0.2</version>
-</dependency>
-```
-
-### Gradle:
-```kotlin
-implementation("com.atlassian.prosemirror:collab:1.0.2")
-```

--- a/history/README.md
+++ b/history/README.md
@@ -4,25 +4,6 @@ previous state but can undo some changes while keeping other, later
 changes intact. (This is necessary for collaborative editing, and
 comes up in other situations as well.)
 
-## Maven / Gradle dependency
-
-Check the latest package at Maven central on: https://packages.atlassian.com/maven-central/com/atlassian/prosemirror/history.
-
-### Maven:
-```xml
-<dependency>
-    <groupId>com.atlassian.prosemirror</groupId>
-    <artifactId>history</artifactId>
-    <version>1.0.2</version>
-</dependency>
-```
-
-### Gradle:
-```kotlin
-implementation("com.atlassian.prosemirror:history:1.0.2")
-```
-
-### Versioning
-
-- Implemented changes to match version [1.4.1](https://github.com/ProseMirror/prosemirror-history/releases/tag/1.4.1) 
+## Versioning
+This module is a port of version [1.4.1](https://github.com/ProseMirror/prosemirror-history/releases/tag/1.4.1) 
 of prosemirror-history

--- a/model/README.md
+++ b/model/README.md
@@ -1,24 +1,6 @@
 This is a core module of ProseMirror. ProseMirror is a well-behaved rich semantic content editor based on contentEditable, 
 with support for collaborative editing and custom document schemas.
 
-## Maven / Gradle dependency
-
-Check the latest package at Maven central on: https://packages.atlassian.com/maven-central/com/atlassian/prosemirror/model.
-
-### Maven:
-```xml
-<dependency>
-    <groupId>com.atlassian.prosemirror</groupId>
-    <artifactId>model</artifactId>
-    <version>1.0.2</version>
-</dependency>
-```
-
-### Gradle:
-```kotlin
-implementation("com.atlassian.prosemirror:model:1.0.2")
-```
-
-### Versioning
-- Implemented changes to match version [1.22.3](https://github.com/ProseMirror/prosemirror-model/releases/tag/1.22.3)
+## Versioning
+This module is a port of version [1.22.3](https://github.com/ProseMirror/prosemirror-model/releases/tag/1.22.3)
   of prosemirror-model

--- a/state/README.md
+++ b/state/README.md
@@ -40,21 +40,3 @@ ProseMirror has a plugin system.
 @PluginView
 @Plugin
 @PluginKey
-
-## Maven / Gradle dependency
-
-Check the latest package at Maven central on: https://packages.atlassian.com/maven-central/com/atlassian/prosemirror/state.
-
-### Maven:
-```xml
-<dependency>
-    <groupId>com.atlassian.prosemirror</groupId>
-    <artifactId>state</artifactId>
-    <version>1.0.2</version>
-</dependency>
-```
-
-### Gradle:
-```kotlin
-implementation("com.atlassian.prosemirror:state:1.0.2")
-```

--- a/test-builder/README.md
+++ b/test-builder/README.md
@@ -72,25 +72,8 @@ node or mark the builder by this name should create.
 Calls `a.eq(b)`. Can be useful to pass as comparison predicate when
 comparing ProseMirror nodes or slices.
 
-## Maven / Gradle dependency
-
-Check the latest package at Maven central on: https://packages.atlassian.com/maven-central/com/atlassian/prosemirror/test-builder.
-
-### Maven:
-```xml
-<dependency>
-    <groupId>com.atlassian.prosemirror</groupId>
-    <artifactId>test-builder</artifactId>
-    <version>1.0.2</version>
-</dependency>
-```
-
-### Gradle:
-```kotlin
-implementation("com.atlassian.prosemirror:test-builder:1.0.2")
-```
-### Versioning
-- Implemented changes to match version:
+## Versioning
+This module is a port of version:
   - [1.1.1](https://github.com/ProseMirror/prosemirror-test-builder/releases/tag/1.1.1)
     of prosemirror-test-builder
   - [1.2.3](https://github.com/ProseMirror/prosemirror-schema-basic/releases/tag/1.2.3)

--- a/transform/README.md
+++ b/transform/README.md
@@ -53,21 +53,3 @@ transformations or determining whether they are even possible.
 @joinPoint
 @insertPoint
 @dropPoint
-
-## Maven / Gradle dependency
-
-Check the latest package at Maven central on: https://packages.atlassian.com/maven-central/com/atlassian/prosemirror/transform.
-
-### Maven:
-```xml
-<dependency>
-    <groupId>com.atlassian.prosemirror</groupId>
-    <artifactId>transform</artifactId>
-    <version>1.0.2</version>
-</dependency>
-```
-
-### Gradle:
-```kotlin
-implementation("com.atlassian.prosemirror:transform:1.0.2")
-```


### PR DESCRIPTION
Clean up readme files so that the dependency instructions are at the top level, and not tied to a specific version.