### PR TITLE
Relaxing node unknownFields to protected

### DIFF
--- a/model/src/commonMain/kotlin/com/atlassian/prosemirror/model/Node.kt
+++ b/model/src/commonMain/kotlin/com/atlassian/prosemirror/model/Node.kt
@@ -66,7 +66,7 @@ open class Node constructor(
     val marks: List<Mark> = Mark.none
 ) : NodeBase(type, attrs) {
 
-    private var unknownFields: Map<String, JsonElement>? = null
+    protected var unknownFields: Map<String, JsonElement>? = null
 
     // A container holding the node's children.
     val content: Fragment


### PR DESCRIPTION
We might need to read some of the `unknownFields`stored on Node to provide extra attributes to some Nodes. 
An example is the Doc.version - it wasn't defined as a node attribute, so we need to read `unknownFields` and populate a new field to expose the version.