### PR TITLE
Bump version and update workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,9 +2,7 @@ name: Publish to artifactory on release branch
 
 on:
   push:
-    # Sequence of patterns matched against refs/tags
-    tags:
-      - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+    branches: [ "release" ]
 
 jobs:
   build:

--- a/.github/workflows/publish_ios.yml
+++ b/.github/workflows/publish_ios.yml
@@ -1,10 +1,8 @@
-name: Publish to artifactory on release branch
+name: Create release and upload iOS artifacts
 
 on:
   push:
-    # Sequence of patterns matched against refs/tags
-    tags:
-      - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+    branches: [ "release" ]
 
 jobs:
   build:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,4 +21,7 @@ Prior to accepting your contributions we ask that you please follow the appropri
 To create a release, follow these steps:
 1. Update the version in the `build.gradle.kts` file.
 2. Create a PR with these changes, targeting the `main` branch.
-3. Once the PR is merged, create a new tag with the format `v*` e.g. `v1.1.0`. The CI/CD pipeline will create a release and publish it to Artifactory.
+3. Once the PR is merged, create a PR to merge `main` into `release` branch.
+4. Once the 2nd PR is merged, the CI/CD pipeline will create a release, upload iOS assets and publish Android binaries to Artifactory.
+5. Create a new tag with the format `v*` (e.g. `v1.1.0`) on the `release` branch.
+4. Once the release is created, edit the release in the Github UI to add release notes for this release (using `Generate release notes`).

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,7 +21,7 @@ dependencies {
 
 allprojects {
   group = "com.atlassian.prosemirror"
-  version = "1.1.0"
+  version = "1.1.1"
 }
 
 val javaVersion = JavaVersion.VERSION_17


### PR DESCRIPTION
Revert the previous change to workflows for publishing. Now, publishing is triggered by a push to `release` branch.
We revert back to releasing and tagging on the `release` branch because that was a security issue with releasing from a tag.