### PR TITLE
Only publish jvm jar to maven. Don't need the ios ones.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -68,7 +68,7 @@ jobs:
 
       # Android: Publishes to Artifactory
       - name: "Publish to artifactory"
-        run: ./gradlew assemble --no-configuration-cache && ./gradlew publish --no-configuration-cache --stacktrace
+        run: ./gradlew assemble --no-configuration-cache && ./gradlew publishJvmPublicationToMavenRepository --no-configuration-cache --stacktrace
 
       # iOS: Build and publish xcframeworks to the GitHub release
       - name: "Build xcframework"


### PR DESCRIPTION
Our publish action is publishing jars for ios platform too. Our artifactory directory looks like:
```
collab/
collab-iosarm64/
collab-iossimulatorarm64/
collab-iosx64/
collab-jvm/
```
and inside each directory looks something like:
```
collab-iossimulatorarm64-1.1.3-metadata.jar
collab-iossimulatorarm64-1.1.3-metadata.jar.asc
collab-iossimulatorarm64-1.1.3-sources.jar
collab-iossimulatorarm64-1.1.3-sources.jar.asc
collab-iossimulatorarm64-1.1.3.klib
collab-iossimulatorarm64-1.1.3.klib.asc
collab-iossimulatorarm64-1.1.3.module
collab-iossimulatorarm64-1.1.3.module.asc
collab-iossimulatorarm64-1.1.3.pom
collab-iossimulatorarm64-1.1.3.pom.asc
```

I don't think we need the ios verions of this, so I've changed it to only publish the jvm versions.