### PR TITLE
Add a flag to configure whether we check attributes against the schema

### DIFF
--- a/model/config/ktlint/baseline.xml
+++ b/model/config/ktlint/baseline.xml
@@ -104,7 +104,8 @@
         <error line="308" column="22" source="standard:function-signature" />
         <error line="308" column="38" source="standard:function-signature" />
         <error line="308" column="57" source="standard:function-signature" />
-        <error line="308" column="80" source="standard:function-signature" />
+        <error line="308" column="82" source="standard:function-signature" />
+        <error line="308" column="104" source="standard:function-signature" />
         <error line="325" column="47" source="standard:multiline-expression-wrapping" />
         <error line="362" column="14" source="standard:function-signature" />
         <error line="362" column="26" source="standard:function-signature" />
@@ -227,12 +228,13 @@
         <error line="104" column="22" source="standard:function-signature" />
         <error line="104" column="38" source="standard:function-signature" />
         <error line="104" column="57" source="standard:function-signature" />
-        <error line="104" column="80" source="standard:function-signature" />
+        <error line="104" column="82" source="standard:function-signature" />
+        <error line="104" column="104" source="standard:function-signature" />
         <error line="107" column="24" source="standard:multiline-expression-wrapping" />
         <error line="115" column="24" source="standard:multiline-expression-wrapping" />
-        <error line="128" column="21" source="standard:function-signature" />
-        <error line="128" column="36" source="standard:function-signature" />
-        <error line="128" column="49" source="standard:function-signature" />
+        <error line="130" column="21" source="standard:function-signature" />
+        <error line="130" column="36" source="standard:function-signature" />
+        <error line="130" column="49" source="standard:function-signature" />
     </file>
     <file name="src/commonMain/kotlin/com/atlassian/prosemirror/model/Node.kt">
         <error line="44" column="1" source="standard:no-consecutive-blank-lines" />
@@ -302,19 +304,20 @@
         <error line="635" column="22" source="standard:function-signature" />
         <error line="635" column="38" source="standard:function-signature" />
         <error line="635" column="57" source="standard:function-signature" />
-        <error line="635" column="80" source="standard:function-signature" />
+        <error line="635" column="82" source="standard:function-signature" />
+        <error line="635" column="104" source="standard:function-signature" />
         <error line="649" column="25" source="standard:multiline-expression-wrapping" />
         <error line="653" column="24" source="standard:multiline-expression-wrapping" />
         <error line="660" column="43" source="standard:multiline-expression-wrapping" />
-        <error line="707" column="21" source="standard:function-signature" />
-        <error line="707" column="32" source="standard:function-signature" />
-        <error line="707" column="39" source="standard:function-signature" />
-        <error line="724" column="22" source="standard:function-signature" />
-        <error line="724" column="33" source="standard:function-signature" />
-        <error line="724" column="41" source="standard:function-signature" />
-        <error line="761" column="15" source="standard:function-signature" />
-        <error line="761" column="34" source="standard:function-signature" />
-        <error line="761" column="45" source="standard:function-signature" />
+        <error line="709" column="21" source="standard:function-signature" />
+        <error line="709" column="32" source="standard:function-signature" />
+        <error line="709" column="39" source="standard:function-signature" />
+        <error line="726" column="22" source="standard:function-signature" />
+        <error line="726" column="33" source="standard:function-signature" />
+        <error line="726" column="41" source="standard:function-signature" />
+        <error line="763" column="15" source="standard:function-signature" />
+        <error line="763" column="34" source="standard:function-signature" />
+        <error line="763" column="45" source="standard:function-signature" />
     </file>
     <file name="src/commonMain/kotlin/com/atlassian/prosemirror/model/Platform.kt">
         <error line="9" column="30" source="standard:function-signature" />
@@ -528,10 +531,12 @@
         <error line="792" column="50" source="standard:function-signature" />
         <error line="797" column="22" source="standard:function-signature" />
         <error line="797" column="41" source="standard:function-signature" />
-        <error line="797" column="64" source="standard:function-signature" />
+        <error line="797" column="66" source="standard:function-signature" />
+        <error line="797" column="88" source="standard:function-signature" />
         <error line="802" column="22" source="standard:function-signature" />
         <error line="802" column="41" source="standard:function-signature" />
-        <error line="802" column="64" source="standard:function-signature" />
+        <error line="802" column="66" source="standard:function-signature" />
+        <error line="802" column="88" source="standard:function-signature" />
         <error line="812" column="17" source="standard:function-signature" />
         <error line="812" column="33" source="standard:function-signature" />
         <error line="812" column="52" source="standard:function-signature" />

--- a/model/src/commonMain/kotlin/com/atlassian/prosemirror/model/Fragment.kt
+++ b/model/src/commonMain/kotlin/com/atlassian/prosemirror/model/Fragment.kt
@@ -305,10 +305,10 @@ class Fragment {
 
     companion object {
         // Deserialize a fragment from its JSON representation.
-        fun fromJSON(schema: Schema, value: JsonArray?, withId: Boolean = false): Fragment {
+        fun fromJSON(schema: Schema, value: JsonArray?, withId: Boolean = false, check: Boolean = false): Fragment {
             if (value == null) return empty
 //            if (!Array.isArray(value)) throw RangeError("Invalid input for Fragment.fromJSON")
-            return Fragment(value.map { el -> schema.nodeFromJSON(el.jsonObject, withId) })
+            return Fragment(value.map { el -> schema.nodeFromJSON(el.jsonObject, withId, check) })
         }
 
         // Build a fragment from an array of nodes. Ensures that adjacent text nodes with the same

--- a/model/src/commonMain/kotlin/com/atlassian/prosemirror/model/Mark.kt
+++ b/model/src/commonMain/kotlin/com/atlassian/prosemirror/model/Mark.kt
@@ -101,7 +101,7 @@ open class Mark constructor(
         val none = emptyList<Mark>()
 
         // Deserialize a mark from JSON.
-        fun fromJSON(schema: Schema, json: JsonObject?, withId: Boolean = false): Mark {
+        fun fromJSON(schema: Schema, json: JsonObject?, withId: Boolean = false, check: Boolean = false): Mark {
             if (json == null) throw RangeError("Invalid input for Mark.fromJSON")
             val jsonType = json["type"]?.jsonPrimitive?.contentOrNull
             val type = schema.marks[jsonType]
@@ -120,7 +120,9 @@ open class Mark constructor(
             } else {
                 type.create(attrs).also { (it as? UnsupportedMark)?.originalMarkName = jsonType }
             }
-            type.checkAttrs(mark.attrs)
+            if (check) {
+                type.checkAttrs(mark.attrs)
+            }
             return mark
         }
 

--- a/model/src/commonMain/kotlin/com/atlassian/prosemirror/model/Node.kt
+++ b/model/src/commonMain/kotlin/com/atlassian/prosemirror/model/Node.kt
@@ -632,12 +632,12 @@ open class Node constructor(
 
         // Deserialize a node from its JSON representation.
         @Suppress("ThrowsCount", "SwallowedException", "ComplexMethod")
-        fun fromJSON(schema: Schema, json: JsonObject?, withId: Boolean = false): Node {
+        fun fromJSON(schema: Schema, json: JsonObject?, withId: Boolean = false, check: Boolean = false): Node {
             if (json == null) throw RangeError("Invalid input for Node.fromJSON")
             var marks: List<Mark>? = null
             if (json.containsKey("marks")) {
                 val marksArray = json["marks"]!!.jsonArray
-                marks = marksArray.map { schema.markFromJSON(it.jsonObject, withId) }
+                marks = marksArray.map { schema.markFromJSON(it.jsonObject, withId, check) }
             }
             val type = json["type"]?.jsonPrimitive?.contentOrNull
             if (type == "text") {
@@ -645,7 +645,7 @@ open class Node constructor(
                 if (text?.isString != true) throw RangeError("Invalid text node in JSON")
                 return schema.text(text.content, marks)
             }
-            val content = Fragment.fromJSON(schema, json["content"]?.jsonArray, withId)
+            val content = Fragment.fromJSON(schema, json["content"]?.jsonArray, withId, check)
             val attrs = json["attrs"]?.jsonObject?.mapValues {
                 if (it.value is JsonNull) null else JSON.decodeFromJsonElement<Any>(it.value)
             }
@@ -674,7 +674,9 @@ open class Node constructor(
                 // for round tripping
                 node.unknownFields = json.fieldsExcept("marks", "type", "content", "attrs")
             }
-            node.type.checkAttrs(node.attrs)
+            if (check) {
+                node.type.checkAttrs(node.attrs)
+            }
             return node
         }
     }

--- a/model/src/commonMain/kotlin/com/atlassian/prosemirror/model/Schema.kt
+++ b/model/src/commonMain/kotlin/com/atlassian/prosemirror/model/Schema.kt
@@ -794,13 +794,13 @@ class Schema {
     }
 
     // Deserialize a node from its JSON representation. This method is bound.
-    fun nodeFromJSON(json: JsonObject?, withId: Boolean = false): Node {
-        return Node.fromJSON(this, json, withId)
+    fun nodeFromJSON(json: JsonObject?, withId: Boolean = false, check: Boolean = false): Node {
+        return Node.fromJSON(this, json, withId, check)
     }
 
     // Deserialize a mark from its JSON representation. This method is bound.
-    fun markFromJSON(json: JsonObject?, withId: Boolean = false): Mark {
-        return Mark.fromJSON(this, json, withId)
+    fun markFromJSON(json: JsonObject?, withId: Boolean = false, check: Boolean = false): Mark {
+        return Mark.fromJSON(this, json, withId, check)
     }
 
     fun nodeType(name: String): NodeType {

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-projectVersion=1.1.3
+projectVersion=1.1.4


### PR DESCRIPTION
Not sure why `checkAttrs` was added to `Node.toJSON` in the original TS code, especially since `Node.toJSON` doesn't check if the node structure is correct anyway.

Since we want to be able to parse JSON and render it, even if it doesn't conform to the schema, I've added a flag to toggle whether we should call `checkAttrs` or not.

Context: `checkAttrs` throws a RangeException if it sees an attribute that it isn't expecting based on the schema.