### PR TITLE
Fixing javadoc generation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -68,7 +68,7 @@ jobs:
 
       # Android: Publishes to Artifactory
       - name: "Publish to artifactory"
-        run: ./gradlew assemble --no-configuration-cache && ./gradlew publish --no-configuration-cache --stacktrace
+        run: ./gradlew javadocJar assemble --no-configuration-cache && ./gradlew publish --no-configuration-cache --stacktrace
 
       # iOS: Build and publish xcframeworks to the GitHub release
       - name: "Build xcframework"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -67,25 +67,20 @@ subprojects {
             remoteLineSuffix.set("#lines-")
           }
         }
-
-        val nativeMain by getting {
-          sourceLink {
-            // Unix based directory relative path to the root of the project (where you execute gradle respectively).
-            localDirectory.set(file("src/nativeMain/kotlin"))
-
-            // URL showing where the source code can be accessed through the web browser
-            remoteUrl.set(URL("${srcUrl}src/main/src/nativeMain/kotlin"))
-
-            // Suffix which is used to append the line number to the URL. Use #L for GitHub
-            remoteLineSuffix.set("#lines-")
-          }
-        }
       }
+    }
+
+    val dokkaHtml by project.tasks.getting(org.jetbrains.dokka.gradle.DokkaTask::class)
+    val javadocJar: TaskProvider<Jar> by project.tasks.registering(Jar::class) {
+      dependsOn(dokkaHtml)
+      archiveClassifier.set("javadoc")
+      from(dokkaHtml.outputDirectory)
     }
 
     publishing {
       publications {
         publications.withType<MavenPublication> {
+          artifact(javadocJar)
           pom {
             name.set(project.name)
             description.set(project.ext.get("pomDescription") as String)

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-projectVersion=1.1.5
+projectVersion=1.1.6


### PR DESCRIPTION
We have an [issue](https://github.com/atlassian-labs/prosemirror-kotlin/issues/61) where the jvm jar is not being propagated to the external maven. This happens because Dokka doesn't support javadoc generation on Multiplaform projects. 

To fix this problem I had to

- Create a custom task to create javadoc
- Updating building script to create the javadoc jar with the new custom task
- Bumping version to 1.1.6 to release a new version

![image](https://github.com/user-attachments/assets/e65fe88f-343c-4b2f-a65a-70c4fc6d5136)
