### PR TITLE
Fixing deploy to maven-central

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,6 +38,24 @@ subprojects {
   apply(plugin = "signing")
   apply(plugin = "org.jetbrains.dokka") // TODO: use alias
 
+  plugins.withId("maven-publish") {
+    // Register an empty javadoc jar for Maven Central compliance
+    val emptyJavadocJar by tasks.registering(Jar::class) {
+      archiveClassifier.set("javadoc")
+      // No content needed
+    }
+
+    afterEvaluate {
+      publishing {
+        publications.withType<MavenPublication>().configureEach {
+          if (name == "jvm") {
+            artifact(tasks.named("emptyJavadocJar"))
+          }
+        }
+      }
+    }
+  }
+
   val srcUrl = "https://github.com/atlassian-labs/prosemirror-kotlin/tree/main/${project.name}/"
   afterEvaluate { // afterEvaluate so that project.ext values will be available
     project.tasks.dokkaHtml {

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-projectVersion=1.1.9
+projectVersion=1.1.10


### PR DESCRIPTION
While evaluating some AI tools, I decided to test them by fixing a real-world [bug](https://github.com/atlassian-labs/prosemirror-kotlin/issues/61). The issue involved deploying JVM artifacts to Maven Central, which was blocked due to the Dokka plugin not supporting Javadoc generation for Kotlin Multiplatform projects.

The AI suggested creating an empty Javadoc JAR as a workaround. Although not ideal, this approach unblocks the deployment and allows users to easily consume the library. We can revisit this later and explore alternative plugins to properly generate the Javadoc.

I've tested it locally running `./gradlew publishToMavenLocal` and it worked fine

<img width="661" alt="image" src="https://github.com/user-attachments/assets/e674c4a9-37c0-4a0a-8fd7-443d0f275b05" />
