### PR TITLE
ME-6962: Fixed node.copy returning node with identical NodeID

### DIFF
--- a/model/src/commonMain/kotlin/com/atlassian/prosemirror/model/Node.kt
+++ b/model/src/commonMain/kotlin/com/atlassian/prosemirror/model/Node.kt
@@ -363,15 +363,6 @@ open class Node constructor(
             Mark.sameSet(this.marks, marks ?: Mark.none)
     }
 
-    // Create a new node with the same markup as this node, containing the given content
-    // (or empty, if no content is given).
-    fun copy(content: Fragment? = null): Node {
-        if (content == this.content) return this
-        return this.type.creator.create(this.type, this.attrs, content, this.marks).also {
-            it.unknownFields = this.unknownFields
-        }
-    }
-
     // Always create a new node with the same markup and attributes as this node, containing the given content
     // (or empty, if no content is given).
     fun copy(content: Fragment? = null, attrs: Attrs? = null): Node {

--- a/model/src/commonTest/kotlin/com/atlassian/prosemirror/model/NodeTest.kt
+++ b/model/src/commonTest/kotlin/com/atlassian/prosemirror/model/NodeTest.kt
@@ -5,6 +5,7 @@ package com.atlassian.prosemirror.model
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isInstanceOf
+import assertk.assertions.isNotEqualTo
 import assertk.assertions.isNotNull
 import assertk.assertions.isNull
 import assertk.assertions.isTrue
@@ -342,6 +343,13 @@ class NodeTest {
 
     @Test
     fun `accepts null`() = from(null, p {})
+
+    @Test
+    fun `empty to empty copy has new nodeId`() {
+        val input = p {}
+        val output = input.copy(Fragment.empty)
+        assertThat(input.nodeId).isNotEqualTo(output.nodeId)
+    }
 
     @Test
     fun `joins adjacent text`() = from(listOf(schema.text("a"), schema.text("b")), p { +"ab" })


### PR DESCRIPTION
Since we converted from ts to kt and added the concept of NodeID, the existing logic of `if (content == this.content) return this` is no longer correct as it'll "copy" a node but return a node with the same NodeID, causing various problems. We need to do a proper copy every time (thus generating a new NodeID).

Since the overload already covers this (but without the problematic shortcut), it's fine to just delete this.