### PR TITLE
ME-7148: Replace use of Stately on JVM targets due to concurrency crash

### DIFF
--- a/model/build.gradle.kts
+++ b/model/build.gradle.kts
@@ -35,7 +35,6 @@ kotlin {
   sourceSets {
     commonMain.dependencies {
       implementation(libs.kotlinx.serialization.json)
-      implementation(libs.stately.concurrent.collections)
       implementation(project(":util"))
       api(libs.ksoup)
     }

--- a/model/src/commonMain/kotlin/com/atlassian/prosemirror/model/ResolvedPos.kt
+++ b/model/src/commonMain/kotlin/com/atlassian/prosemirror/model/ResolvedPos.kt
@@ -1,6 +1,6 @@
 package com.atlassian.prosemirror.model
 
-import co.touchlab.stately.collections.ConcurrentMutableList
+import com.atlassian.prosemirror.util.ConcurrentMutableList
 import kotlinx.atomicfu.atomic
 import kotlinx.atomicfu.update
 

--- a/model/src/commonMain/kotlin/com/atlassian/prosemirror/model/Schema.kt
+++ b/model/src/commonMain/kotlin/com/atlassian/prosemirror/model/Schema.kt
@@ -2,7 +2,7 @@
 
 package com.atlassian.prosemirror.model
 
-import co.touchlab.stately.collections.ConcurrentMutableMap
+import com.atlassian.prosemirror.util.ConcurrentMutableMap
 import com.atlassian.prosemirror.util.slice
 import com.atlassian.prosemirror.util.verbose
 import kotlinx.serialization.json.JsonObject

--- a/util/build.gradle.kts
+++ b/util/build.gradle.kts
@@ -33,6 +33,7 @@ kotlin {
 
   sourceSets {
     commonMain.dependencies {
+      implementation(libs.stately.concurrent.collections)
     }
     commonTest.dependencies {
       implementation(libs.kotlin.test)

--- a/util/build.gradle.kts
+++ b/util/build.gradle.kts
@@ -32,7 +32,7 @@ kotlin {
   }
 
   sourceSets {
-    commonMain.dependencies {
+    nativeMain.dependencies {
       implementation(libs.stately.concurrent.collections)
     }
     commonTest.dependencies {

--- a/util/src/commonMain/kotlin/com/atlassian/prosemirror/util/ConcurrentMutableList.kt
+++ b/util/src/commonMain/kotlin/com/atlassian/prosemirror/util/ConcurrentMutableList.kt
@@ -1,0 +1,25 @@
+package com.atlassian.prosemirror.util
+
+expect class ConcurrentMutableList<T : Any>() : MutableList<T> {
+    override val size: Int
+    override fun isEmpty(): Boolean
+    override fun contains(element: T): Boolean
+    override fun containsAll(elements: Collection<T>): Boolean
+    override fun get(index: Int): T
+    override fun indexOf(element: T): Int
+    override fun lastIndexOf(element: T): Int
+    override fun iterator(): MutableIterator<T>
+    override fun listIterator(): MutableListIterator<T>
+    override fun listIterator(index: Int): MutableListIterator<T>
+    override fun subList(fromIndex: Int, toIndex: Int): MutableList<T>
+    override fun add(element: T): Boolean
+    override fun add(index: Int, element: T)
+    override fun addAll(elements: Collection<T>): Boolean
+    override fun addAll(index: Int, elements: Collection<T>): Boolean
+    override fun remove(element: T): Boolean
+    override fun removeAt(index: Int): T
+    override fun removeAll(elements: Collection<T>): Boolean
+    override fun retainAll(elements: Collection<T>): Boolean
+    override fun clear()
+    override fun set(index: Int, element: T): T
+}

--- a/util/src/commonMain/kotlin/com/atlassian/prosemirror/util/ConcurrentMutableMap.kt
+++ b/util/src/commonMain/kotlin/com/atlassian/prosemirror/util/ConcurrentMutableMap.kt
@@ -1,0 +1,16 @@
+package com.atlassian.prosemirror.util
+
+expect class ConcurrentMutableMap<Key : Any, Value : Any>() : MutableMap<Key, Value> {
+    override val size: Int
+    override val keys: MutableSet<Key>
+    override val values: MutableCollection<Value>
+    override fun isEmpty(): Boolean
+    override fun containsKey(key: Key): Boolean
+    override fun containsValue(value: Value): Boolean
+    override val entries: MutableSet<MutableMap.MutableEntry<Key, Value>>
+    override operator fun get(key: Key): Value?
+    override fun put(key: Key, value: Value): Value?
+    override fun remove(key: Key): Value?
+    override fun putAll(from: Map<out Key, Value>)
+    override fun clear()
+}

--- a/util/src/jvmMain/kotlin/com/atlassian/prosemirror/util/ConcurrentMutableList.kt
+++ b/util/src/jvmMain/kotlin/com/atlassian/prosemirror/util/ConcurrentMutableList.kt
@@ -1,0 +1,90 @@
+package com.atlassian.prosemirror.util
+
+import java.util.Collections
+
+actual class ConcurrentMutableList<T : Any> : MutableList<T> {
+    private val list = Collections.synchronizedList(mutableListOf<T>())
+
+    actual override val size: Int
+        get() = list.size
+
+    actual override fun isEmpty(): Boolean {
+        return list.isEmpty()
+    }
+
+    actual override fun contains(element: T): Boolean {
+        return list.contains(element)
+    }
+
+    actual override fun containsAll(elements: Collection<T>): Boolean {
+        return list.containsAll(elements)
+    }
+
+    actual override fun get(index: Int): T {
+        return list[index]
+    }
+
+    actual override fun indexOf(element: T): Int {
+        return list.indexOf(element)
+    }
+
+    actual override fun lastIndexOf(element: T): Int {
+        return list.lastIndexOf(element)
+    }
+
+    actual override fun iterator(): MutableIterator<T> {
+        return list.iterator()
+    }
+
+    actual override fun listIterator(): MutableListIterator<T> {
+        return list.listIterator()
+    }
+
+    actual override fun listIterator(index: Int): MutableListIterator<T> {
+        return list.listIterator(index)
+    }
+
+    actual override fun subList(fromIndex: Int, toIndex: Int): MutableList<T> {
+        return list.subList(fromIndex, toIndex)
+    }
+
+    actual override fun add(element: T): Boolean {
+        return list.add(element)
+    }
+
+    actual override fun add(index: Int, element: T) {
+        list.add(index, element)
+    }
+
+    actual override fun addAll(elements: Collection<T>): Boolean {
+        return list.addAll(elements)
+    }
+
+    actual override fun addAll(index: Int, elements: Collection<T>): Boolean {
+        return list.addAll(index, elements)
+    }
+
+    actual override fun remove(element: T): Boolean {
+        return list.remove(element)
+    }
+
+    actual override fun removeAt(index: Int): T {
+        return list.removeAt(index)
+    }
+
+    actual override fun removeAll(elements: Collection<T>): Boolean {
+        return list.removeAll(elements)
+    }
+
+    actual override fun retainAll(elements: Collection<T>): Boolean {
+        return list.retainAll(elements)
+    }
+
+    actual override fun clear() {
+        list.clear()
+    }
+
+    actual override fun set(index: Int, element: T): T {
+        return list.set(index, element)
+    }
+}

--- a/util/src/jvmMain/kotlin/com/atlassian/prosemirror/util/ConcurrentMutableMap.kt
+++ b/util/src/jvmMain/kotlin/com/atlassian/prosemirror/util/ConcurrentMutableMap.kt
@@ -1,0 +1,48 @@
+package com.atlassian.prosemirror.util
+
+import java.util.concurrent.ConcurrentHashMap
+
+actual class ConcurrentMutableMap<Key : Any, Value : Any> : MutableMap<Key, Value> {
+    private val map = ConcurrentHashMap<Key, Value>()
+    actual override val size: Int
+        get() = map.size
+    actual override val keys: MutableSet<Key>
+        get() = map.keys
+    actual override val values: MutableCollection<Value>
+        get() = map.values
+
+    actual override fun isEmpty(): Boolean {
+        return map.isEmpty()
+    }
+
+    actual override fun containsKey(key: Key): Boolean {
+        return map.containsKey(key)
+    }
+
+    actual override fun containsValue(value: Value): Boolean {
+        return map.containsValue(value)
+    }
+
+    actual override val entries: MutableSet<MutableMap.MutableEntry<Key, Value>>
+        get() = map.entries
+
+    actual override operator fun get(key: Key): Value? {
+        return map[key]
+    }
+
+    actual override fun put(key: Key, value: Value): Value? {
+        return map.put(key, value)
+    }
+
+    actual override fun remove(key: Key): Value? {
+        return map.remove(key)
+    }
+
+    actual override fun putAll(from: Map<out Key, Value>) {
+        map.putAll(from)
+    }
+
+    actual override fun clear() {
+        map.clear()
+    }
+}

--- a/util/src/nativeMain/kotlin/com/atlassian/prosemirror/util/ConcurrentMutableList.native.kt
+++ b/util/src/nativeMain/kotlin/com/atlassian/prosemirror/util/ConcurrentMutableList.native.kt
@@ -1,0 +1,90 @@
+package com.atlassian.prosemirror.util
+
+import co.touchlab.stately.collections.ConcurrentMutableList as StatelyConcurrentMutableList
+
+actual class ConcurrentMutableList<T : Any> : MutableList<T> {
+    private val list = StatelyConcurrentMutableList<T>()
+
+    actual override val size: Int
+        get() = list.size
+
+    actual override fun isEmpty(): Boolean {
+        return list.isEmpty()
+    }
+
+    actual override fun contains(element: T): Boolean {
+        return list.contains(element)
+    }
+
+    actual override fun containsAll(elements: Collection<T>): Boolean {
+        return list.containsAll(elements)
+    }
+
+    actual override fun get(index: Int): T {
+        return list[index]
+    }
+
+    actual override fun indexOf(element: T): Int {
+        return list.indexOf(element)
+    }
+
+    actual override fun lastIndexOf(element: T): Int {
+        return list.lastIndexOf(element)
+    }
+
+    actual override fun iterator(): MutableIterator<T> {
+        return list.iterator()
+    }
+
+    actual override fun listIterator(): MutableListIterator<T> {
+        return list.listIterator()
+    }
+
+    actual override fun listIterator(index: Int): MutableListIterator<T> {
+        return list.listIterator(index)
+    }
+
+    actual override fun subList(fromIndex: Int, toIndex: Int): MutableList<T> {
+        return list.subList(fromIndex, toIndex)
+    }
+
+    actual override fun add(element: T): Boolean {
+        return list.add(element)
+    }
+
+    actual override fun add(index: Int, element: T) {
+        list.add(index, element)
+    }
+
+    actual override fun addAll(elements: Collection<T>): Boolean {
+        return list.addAll(elements)
+    }
+
+    actual override fun addAll(index: Int, elements: Collection<T>): Boolean {
+        return list.addAll(index, elements)
+    }
+
+    actual override fun remove(element: T): Boolean {
+        return list.remove(element)
+    }
+
+    actual override fun removeAt(index: Int): T {
+        return list.removeAt(index)
+    }
+
+    actual override fun removeAll(elements: Collection<T>): Boolean {
+        return list.removeAll(elements)
+    }
+
+    actual override fun retainAll(elements: Collection<T>): Boolean {
+        return list.retainAll(elements)
+    }
+
+    actual override fun clear() {
+        list.clear()
+    }
+
+    actual override fun set(index: Int, element: T): T {
+        return list.set(index, element)
+    }
+}

--- a/util/src/nativeMain/kotlin/com/atlassian/prosemirror/util/ConcurrentMutableMap.native.kt
+++ b/util/src/nativeMain/kotlin/com/atlassian/prosemirror/util/ConcurrentMutableMap.native.kt
@@ -1,0 +1,49 @@
+package com.atlassian.prosemirror.util
+
+import co.touchlab.stately.collections.ConcurrentMutableMap as StatelyConcurrentMutableMap
+
+actual class ConcurrentMutableMap<Key : Any, Value : Any> : MutableMap<Key, Value> {
+    private val map = StatelyConcurrentMutableMap<Key, Value>()
+
+    actual override val size: Int
+        get() = map.size
+    actual override val keys: MutableSet<Key>
+        get() = map.keys
+    actual override val values: MutableCollection<Value>
+        get() = map.values
+
+    actual override fun isEmpty(): Boolean {
+        return map.isEmpty()
+    }
+
+    actual override fun containsKey(key: Key): Boolean {
+        return map.containsKey(key)
+    }
+
+    actual override fun containsValue(value: Value): Boolean {
+        return map.containsValue(value)
+    }
+
+    actual override val entries: MutableSet<MutableMap.MutableEntry<Key, Value>>
+        get() = map.entries
+
+    actual override operator fun get(key: Key): Value? {
+        return map[key]
+    }
+
+    actual override fun put(key: Key, value: Value): Value? {
+        return map.put(key, value)
+    }
+
+    actual override fun remove(key: Key): Value? {
+        return map.remove(key)
+    }
+
+    actual override fun putAll(from: Map<out Key, Value>) {
+        map.putAll(from)
+    }
+
+    actual override fun clear() {
+        map.clear()
+    }
+}


### PR DESCRIPTION
Aforementioned issue: https://github.com/touchlab/Stately/issues/105

For JVM, fall back to JVM implementations of ConcurrentMap and List, but keep using existing stately implementations otherwise.

I considered using https://api.ktor.io/ktor-utils/io.ktor.util.collections/-concurrent-map/index.html, but sadly they don't have a List implementation anymore (they used to...)