### PR TITLE
ME-7843 - ConcurrentModificationException crash in iterator

### DIFF
--- a/util/src/jvmMain/kotlin/com/atlassian/prosemirror/util/ConcurrentMutableList.kt
+++ b/util/src/jvmMain/kotlin/com/atlassian/prosemirror/util/ConcurrentMutableList.kt
@@ -1,9 +1,9 @@
 package com.atlassian.prosemirror.util
 
-import java.util.Collections
+import java.util.concurrent.CopyOnWriteArrayList
 
 actual class ConcurrentMutableList<T : Any> : MutableList<T> {
-    private val list = Collections.synchronizedList(mutableListOf<T>())
+    private val list = CopyOnWriteArrayList<T>()
 
     actual override val size: Int
         get() = list.size


### PR DESCRIPTION
In the JVM implementation, switch from synchronizedList to CopyOnWriteArrayList because synchronizedList can't handle iterators. Actually, the old implementation I did for ME-3981 used this.

The notes I wrote at that time when I implemented this in MK;

```
/**
 * From some testing on mix-contents.json (will differ based on document etc.);
 * Initial Render: 3:1 interating (reads) vs writing
 * Selection: ~10:1
 * Typing: ~5:1
 *
 * Therefore, CopyOnWriteArrayList is probably preferable to synchronizing out traversals (w/synchronizedList),
 * despite the penalty of having to copy on write (the size is only 12 anyway).
 */
```