### PR TITLE
ME-8689 Unsupported node updates

### DIFF
--- a/model/src/commonMain/kotlin/com/atlassian/prosemirror/model/Node.kt
+++ b/model/src/commonMain/kotlin/com/atlassian/prosemirror/model/Node.kt
@@ -542,9 +542,18 @@ open class Node constructor(
         }
     }
 
+    /**
+     * Validates only the content-nesting rules of this node and all its descendants, without
+     * checking mark attributes or node attributes. Throws [InvalidContentError] if any nodes
+     * children violate its content expression.
+     */
+    fun checkNesting() {
+        this.type.checkContent(this.content)
+        this.content.forEach { node, _, _ -> node.checkNesting() }
+    }
+
     // Check whether this node and its descendants conform to the
     // schema, and raise an exception when they do not.
-    @Suppress("MagicNumber")
     fun check() {
         this.type.checkContent(this.content)
         this.type.checkAttrs(this.attrs)

--- a/model/src/commonMain/kotlin/com/atlassian/prosemirror/model/Node.kt
+++ b/model/src/commonMain/kotlin/com/atlassian/prosemirror/model/Node.kt
@@ -33,10 +33,6 @@ open class NodeBase(open val type: NodeType, open val attrs: Attrs? = null) {
     }
 }
 
-interface UnsupportedNode {
-    var originalNodeName: String?
-}
-
 @JvmInline
 @kotlinx.serialization.Serializable
 value class NodeId(val id: String)
@@ -628,7 +624,8 @@ open class Node constructor(
                 if (text?.isString != true) throw RangeError("Invalid text node in JSON")
                 return schema.text(text.content, marks)
             }
-            val content = Fragment.fromJSON(schema, json["content"]?.jsonArray, withId, check)
+            val jsonContent = json["content"]?.jsonArray
+            val content = Fragment.fromJSON(schema, jsonContent, withId, check)
             val attrs = json["attrs"]?.jsonObject?.mapValues {
                 if (it.value is JsonNull) null else JSON.decodeFromJsonElement<Any>(it.value)
             }
@@ -640,17 +637,17 @@ open class Node constructor(
                     }
                 }
             } catch (ex: RangeError) {
-                val unsupportedNodeType = if (json["content"] == null) {
-                    schema.spec.unsupportedInlineNode
-                } else {
-                    schema.spec.unsupportedNode
-                }
-                schema.nodeType(unsupportedNodeType).create(attrs, content, marks).also {
+                val unknownNodeType = type ?: throw RangeError("Invalid input for Node.fromJSON")
+                val unsupportedNodeType = schema.spec.unknownNodeFallback?.invoke(unknownNodeType, jsonContent)
+                    ?: if (jsonContent != null) {
+                        schema.spec.unsupportedNode
+                    } else {
+                        schema.spec.unsupportedInlineNode
+                    }
+                val unsupportedAttrs = schema.spec.unknownNodeAttrs?.invoke(unknownNodeType, attrs) ?: attrs
+                schema.nodeType(unsupportedNodeType).create(unsupportedAttrs, content, marks).also {
                     if (withId && id != null) {
                         it.nodeId = NodeId(id)
-                    }
-                    (it as? UnsupportedNode)?.let { unsupportedNode ->
-                        unsupportedNode.originalNodeName = type
                     }
                 }
             }.also { node ->

--- a/model/src/commonMain/kotlin/com/atlassian/prosemirror/model/Schema.kt
+++ b/model/src/commonMain/kotlin/com/atlassian/prosemirror/model/Schema.kt
@@ -469,9 +469,6 @@ data class SchemaSpec(
     // The name of the node for the schema to fall back whenever we encounter unknown node type.
     val unsupportedNode: String = "unsupportedBlock",
 
-    // The name of the leaf node for the schema to fall back whenever we encounter unknown node type.
-    val unsupportedLeafNode: String = "unsupportedLeaf",
-
     // The name of the inline node for the schema to fall back whenever we encounter unknown node type.
     val unsupportedInlineNode: String = "unsupportedInline",
 

--- a/model/src/commonMain/kotlin/com/atlassian/prosemirror/model/Schema.kt
+++ b/model/src/commonMain/kotlin/com/atlassian/prosemirror/model/Schema.kt
@@ -43,7 +43,10 @@ fun initAttrs(typeName: String, attrs: Map<String, AttributeSpec>?): Map<String,
     } ?: emptyMap()
 }
 
-class RangeError(message: String) : IllegalArgumentException("Range Error: $message")
+open class RangeError(message: String) : IllegalArgumentException("Range Error: $message")
+
+/** Thrown when a node's content does not match its content expression (illegal nesting). */
+class InvalidContentError(message: String) : RangeError(message)
 
 // Node types are objects allocated once per `Schema` and used to [tag](#model.Node.type) `Node`
 // instances. They contain information about the node type, such as its name and what kind of nod
@@ -158,7 +161,7 @@ class NodeType internal constructor(
     fun createChecked(attrs: Attrs? = null, content: Node?, marks: List<Mark>? = null): Node {
         val thisContent = Fragment.from(content)
         if (!this.validContent(thisContent)) {
-            throw RangeError(
+            throw InvalidContentError(
                 if (verbose) {
                     "Invalid content for node type $name: $thisContent"
                 } else {
@@ -172,7 +175,7 @@ class NodeType internal constructor(
     fun createChecked(attrs: Attrs? = null, content: List<Node>?, marks: List<Mark>? = null): Node {
         val thisContent = Fragment.from(content)
         if (!this.validContent(thisContent)) {
-            throw RangeError(
+            throw InvalidContentError(
                 if (verbose) {
                     "Invalid content for node type $name: $thisContent"
                 } else {
@@ -238,11 +241,11 @@ class NodeType internal constructor(
         return true
     }
 
-    // Throws a RangeError if the given fragment is not valid content for this
+    // Throws an InvalidContentError if the given fragment is not valid content for this
     // node type.
-    internal fun checkContent(content: Fragment) {
+    fun checkContent(content: Fragment) {
         if (!this.validContent(content)) {
-            throw RangeError(
+            throw InvalidContentError(
                 if (verbose) {
                     "Invalid content for node $name: ${content.toString().slice(0, 50)}"
                 } else {

--- a/model/src/commonMain/kotlin/com/atlassian/prosemirror/model/Schema.kt
+++ b/model/src/commonMain/kotlin/com/atlassian/prosemirror/model/Schema.kt
@@ -5,6 +5,7 @@ package com.atlassian.prosemirror.model
 import com.atlassian.prosemirror.util.ConcurrentMutableMap
 import com.atlassian.prosemirror.util.slice
 import com.atlassian.prosemirror.util.verbose
+import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
 
 // An object holding the attributes of a node.
@@ -463,12 +464,19 @@ data class SchemaSpec(
     val topNode: String? = null,
 
     // The name of the node for the schema to fall back whenever we encounter unknown node type.
-    // The node will have original name saved into originalNodeName field if creator returned UnsupportedNode type
     val unsupportedNode: String = "unsupportedBlock",
 
+    // The name of the leaf node for the schema to fall back whenever we encounter unknown node type.
+    val unsupportedLeafNode: String = "unsupportedLeaf",
+
     // The name of the inline node for the schema to fall back whenever we encounter unknown node type.
-    // The node will have original name saved into originalNodeName field if creator returned UnsupportedNode type
     val unsupportedInlineNode: String = "unsupportedInline",
+
+    // Allows schemas to choose which fallback node type should represent an unknown node.
+    val unknownNodeFallback: ((unknownNodeType: String, content: JsonArray?) -> String?)? = null,
+
+    // Allows schemas to add or rewrite attrs before an unknown node is constructed as a fallback node.
+    val unknownNodeAttrs: ((unknownNodeType: String, attrs: Attrs?) -> Attrs?)? = null,
 
     // The name of the mark for the schema to fall back whenever we encounter unknown mark type.
     // The mark will have original name saved into originalMarkName field if creator returned UnsupportedMark type

--- a/model/src/commonTest/kotlin/com/atlassian/prosemirror/model/NodeTest.kt
+++ b/model/src/commonTest/kotlin/com/atlassian/prosemirror/model/NodeTest.kt
@@ -25,6 +25,7 @@ import kotlin.test.assertFailsWith
 import kotlin.test.fail
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
 
 val customSchemaSpec = SchemaSpec(
     nodes = mapOf(
@@ -353,6 +354,62 @@ class NodeTest {
 
     @Test
     fun `joins adjacent text`() = from(listOf(schema.text("a"), schema.text("b")), p { +"ab" })
+
+    @Test
+    fun `unknown node fallback can inspect raw content`() {
+        val seenContentSizes = mutableMapOf<String, Int?>()
+        val fallbackSchema = Schema(
+            SchemaSpec(
+                nodes = mapOf(
+                    "doc" to NodeSpecImpl(content = "block+"),
+                    "paragraph" to NodeSpecImpl(content = "inline*", group = "block"),
+                    "text" to NodeSpecImpl(),
+                    "fallbackInline" to NodeSpecImpl(inline = true, group = "inline"),
+                    "fallbackLeaf" to NodeSpecImpl(group = "block"),
+                    "fallbackContainer" to NodeSpecImpl(content = "block*", group = "block")
+                ),
+                unsupportedNode = "fallbackContainer",
+                unsupportedInlineNode = "fallbackInline",
+                unknownNodeFallback = { unknownNodeType, content ->
+                    seenContentSizes[unknownNodeType] = content?.size
+                    when (unknownNodeType) {
+                        "unknownLeaf" -> "fallbackLeaf"
+                        "unknownContainer" -> "fallbackContainer"
+                        else -> null
+                    }
+                }
+            )
+        )
+        val doc = Node.fromJSON(
+            fallbackSchema,
+            Json.parseToJsonElement(
+                """
+                    {
+                      "type": "doc",
+                      "content": [
+                        { "type": "paragraph", "content": [{ "type": "unknownInline" }] },
+                        { "type": "unknownLeaf" },
+                        { "type": "unknownContainer", "content": [] },
+                        { "type": "unknownContainerWithChild", "content": [{ "type": "paragraph" }] }
+                      ]
+                    }
+                """.trimIndent()
+            ).jsonObject
+        )
+
+        assertThat(doc.child(0).child(0).type.name).isEqualTo("fallbackInline")
+        assertThat(doc.child(1).type.name).isEqualTo("fallbackLeaf")
+        assertThat(doc.child(2).type.name).isEqualTo("fallbackContainer")
+        assertThat(doc.child(3).type.name).isEqualTo("fallbackContainer")
+        assertThat(seenContentSizes).isEqualTo(
+            mapOf(
+                "unknownInline" to null,
+                "unknownLeaf" to null,
+                "unknownContainer" to 0,
+                "unknownContainerWithChild" to 1
+            )
+        )
+    }
     // endregion
 
     // region Node - toJSON

--- a/transform/src/commonMain/kotlin/com/atlassian/prosemirror/transform/Step.kt
+++ b/transform/src/commonMain/kotlin/com/atlassian/prosemirror/transform/Step.kt
@@ -1,5 +1,6 @@
 package com.atlassian.prosemirror.transform
 
+import com.atlassian.prosemirror.model.InvalidContentError
 import com.atlassian.prosemirror.model.Node
 import com.atlassian.prosemirror.model.RangeError
 import com.atlassian.prosemirror.model.ReplaceError
@@ -88,7 +89,9 @@ class StepResult internal constructor(
     // The transformed document, if successful.
     val doc: Node?,
     // The failure message, if unsuccessful.
-    val failed: String?
+    val failed: String?,
+    // The original failure cause, when a step failed by catching an exception.
+    val failedCause: Throwable? = null,
 ) {
 
     companion object {
@@ -96,7 +99,7 @@ class StepResult internal constructor(
         fun ok(doc: Node) = StepResult(doc, null)
 
         // Create a failed step result.
-        fun fail(message: String) = StepResult(null, message)
+        fun fail(message: String, cause: Throwable? = null) = StepResult(null, message, cause)
 
         // Call [`Node.replace`](#model.Node.replace) with the given arguments. Create a successful
         // result if it succeeds, and a failed one if it throws a `ReplaceError`.
@@ -105,6 +108,8 @@ class StepResult internal constructor(
                 ok(doc.replace(from, to, slice))
             } catch (e: ReplaceError) {
                 fail(e.message)
+            } catch (e: InvalidContentError) {
+                fail(e.message ?: "RangeError", e)
             } catch (e: RangeError) {
                 // TODO: check if still need this catch after updating to latest prosemirror-transform
                 fail(e.message ?: "RangeError")

--- a/transform/src/commonMain/kotlin/com/atlassian/prosemirror/transform/Structure.kt
+++ b/transform/src/commonMain/kotlin/com/atlassian/prosemirror/transform/Structure.kt
@@ -3,6 +3,7 @@ package com.atlassian.prosemirror.transform
 import com.atlassian.prosemirror.model.Attrs
 import com.atlassian.prosemirror.model.ContentMatch
 import com.atlassian.prosemirror.model.Fragment
+import com.atlassian.prosemirror.model.InvalidContentError
 import com.atlassian.prosemirror.model.Mark
 import com.atlassian.prosemirror.model.Node
 import com.atlassian.prosemirror.model.NodeBase
@@ -234,7 +235,7 @@ fun setNodeMarkup(tr: Transform, pos: Int, type: NodeType?, attrs: Attrs?, marks
     }
 
     if (!thisType.validContent(node.content)) {
-        throw RangeError(
+        throw InvalidContentError(
             if (verbose) {
                 "Invalid content for node type ${thisType.name}: ${node.content}"
             } else {

--- a/transform/src/commonMain/kotlin/com/atlassian/prosemirror/transform/Transform.kt
+++ b/transform/src/commonMain/kotlin/com/atlassian/prosemirror/transform/Transform.kt
@@ -47,7 +47,7 @@ open class Transform(
     fun step(step: Step): Transform {
         val result = this.maybeStep(step)
         if (result.failed != null) {
-            val exception = TransformError(result.failed)
+            val exception = TransformError(result.failed, result.failedCause)
             this.error = exception
             if (!safeMode) throw exception
         }

--- a/transform/src/commonTest/kotlin/com/atlassian/prosemirror/transform/TransformTest.kt
+++ b/transform/src/commonTest/kotlin/com/atlassian/prosemirror/transform/TransformTest.kt
@@ -5,6 +5,7 @@ import assertk.assertions.isEqualTo
 import assertk.assertions.isTrue
 import com.atlassian.prosemirror.model.Attrs
 import com.atlassian.prosemirror.model.Fragment
+import com.atlassian.prosemirror.model.InvalidContentError
 import com.atlassian.prosemirror.model.Mark
 import com.atlassian.prosemirror.model.Node
 import com.atlassian.prosemirror.model.NodeBase
@@ -956,6 +957,41 @@ class TransformTest {
             expect,
             useExpectFirstChild
         )
+    }
+
+    @Test
+    fun `preserves invalid content cause in failed replace step result`() {
+        val targetDoc = doc { pre { +"<a>" } }
+        val sourceDoc = doc { p { +"invalid" } }
+        val result = ReplaceStep(
+            pos(targetDoc, "a")!!,
+            pos(targetDoc, "a")!!,
+            sourceDoc.slice(0, sourceDoc.content.size),
+        ).apply(targetDoc)
+
+        assertThat(result.failedCause is InvalidContentError).isTrue()
+    }
+
+    @Test
+    fun `preserves invalid content cause in transform error`() {
+        safeMode = false
+        try {
+            val targetDoc = doc { pre { +"<a>" } }
+            val sourceDoc = doc { p { +"invalid" } }
+            val error = assertFailsWith(TransformError::class) {
+                Transform(targetDoc).step(
+                    ReplaceStep(
+                        pos(targetDoc, "a")!!,
+                        pos(targetDoc, "a")!!,
+                        sourceDoc.slice(0, sourceDoc.content.size),
+                    )
+                )
+            }
+
+            assertThat(error.cause is InvalidContentError).isTrue()
+        } finally {
+            safeMode = true
+        }
     }
 
     @Test

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-projectVersion=1.1.17
+projectVersion=1.1.18


### PR DESCRIPTION
**Breaking Change**: UnsupportedNode interface is removed, consumers can implement this how they want. Reasoning is storing the originalNodeName as a variable like this could be lost during editing operations, and this isn't present in JS prosemirror anyway.

Note nothing in the prosemirror codebase ever used this interface, so...

**Other Changes:**
- More options for integrators to handle unsupported node mapping with `schema.spec.unknownNodeFallback`. If this is null, then the existing behaviour is used, but if it's set, this is used to determine how things are mapped.
- unknownNodeAttrs added so integrator can define how the attributes for the unknown node is written. In our case, we intend for this to allow the original node name to be written in a hidden attribute.
- Seperate InvalidContentError (subclass of RangeError) for that specific error type

Bump project version to 1.1.18