### PR TITLE
Support spec.group with multiple groups

### DIFF
--- a/model/src/commonMain/kotlin/com/atlassian/prosemirror/model/Schema.kt
+++ b/model/src/commonMain/kotlin/com/atlassian/prosemirror/model/Schema.kt
@@ -108,7 +108,7 @@ class NodeType internal constructor(
     var creator: NodeCreator<out Node> = NodeCreator.DEFAULT
 
     init {
-        this.groups = spec.group?.let { listOf(it) } ?: emptyList()
+        this.groups = spec.group?.split(" ") ?: emptyList()
         this.attrs = initAttrs(name, spec.attrs)
         this.defaultAttrs = defaultAttrs(this.attrs)
         this.defaultAttrsIncludingNullValues = defaultAttrs(this.attrs, includeNullValues = true)

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-projectVersion=1.1.18
+projectVersion=1.1.19


### PR DESCRIPTION
This was a ts -> kt conversion error, and it preventing us from having one node in multiple groups (it would be parsed as one group). I also quickly audited dother cases where we split by space and verified they were all converted correctly from ts.

TS line | Purpose | Kotlin equivalent | Status
-- | -- | -- | --
spec.group.split(" ") | Node groups | spec.group?.split(" ") ✅ (just fixed) | ✅ Fixed
markExpr.split(" ") | Node's allowed marks | markExpr.split(" ") in Schema constructor | ✅ OK
excl.split(" ") | Mark excludes | excl.split(" ") in Schema constructor | ✅ OK
mark.spec.group.split(" ").indexOf(name) | Mark group lookup in gatherMarks | it.split(" ").indexOf(name) in gatherMarks() | ✅ OK

Also bump version to prepare for another release with this fix.