### PR TITLE
Unsupported Mark Update

### DIFF
--- a/model/src/commonMain/kotlin/com/atlassian/prosemirror/model/Mark.kt
+++ b/model/src/commonMain/kotlin/com/atlassian/prosemirror/model/Mark.kt
@@ -13,10 +13,6 @@ import kotlinx.serialization.json.encodeToJsonElement
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
 
-interface UnsupportedMark {
-    var originalMarkName: String?
-}
-
 @JvmInline
 @kotlinx.serialization.Serializable
 value class MarkId(val id: String)
@@ -104,21 +100,23 @@ open class Mark constructor(
         fun fromJSON(schema: Schema, json: JsonObject?, withId: Boolean = false, check: Boolean = false): Mark {
             if (json == null) throw RangeError("Invalid input for Mark.fromJSON")
             val jsonType = json["type"]?.jsonPrimitive?.contentOrNull
-            val type = schema.marks[jsonType]
+            val directType = schema.marks[jsonType]
                 ?: schema.marks[jsonType?.lowercase()]
+            val type = directType
                 ?: schema.marks[schema.spec.unsupportedMark]
                 ?: throw RangeError(
                     "There is no mark type '$jsonType' in this schema and 'unsupportedMark' not defined as well"
                 )
-            val attrs: Attrs? = json["attrs"]?.let { JSON.decodeFromJsonElement(it) }
-            val id = json["id"]?.jsonPrimitive?.contentOrNull
-            val mark = if (withId && id != null) {
-                type.create(attrs).also {
-                    it.markId = MarkId(id)
-                    (it as? UnsupportedMark)?.originalMarkName = jsonType
-                }
+            val rawAttrs: Attrs? = json["attrs"]?.let { JSON.decodeFromJsonElement(it) }
+            val attrs = if (directType == null && jsonType != null) {
+                schema.spec.unknownMarkAttrs?.invoke(jsonType, rawAttrs) ?: rawAttrs
             } else {
-                type.create(attrs).also { (it as? UnsupportedMark)?.originalMarkName = jsonType }
+                rawAttrs
+            }
+            val id = json["id"]?.jsonPrimitive?.contentOrNull
+            val mark = type.create(attrs)
+            if (withId && id != null) {
+                mark.markId = MarkId(id)
             }
             if (check) {
                 type.checkAttrs(mark.attrs)

--- a/model/src/commonMain/kotlin/com/atlassian/prosemirror/model/Schema.kt
+++ b/model/src/commonMain/kotlin/com/atlassian/prosemirror/model/Schema.kt
@@ -479,8 +479,10 @@ data class SchemaSpec(
     val unknownNodeAttrs: ((unknownNodeType: String, attrs: Attrs?) -> Attrs?)? = null,
 
     // The name of the mark for the schema to fall back whenever we encounter unknown mark type.
-    // The mark will have original name saved into originalMarkName field if creator returned UnsupportedMark type
-    val unsupportedMark: String = "unsupportedMark"
+    val unsupportedMark: String = "unsupportedMark",
+
+    // Allows schemas to add or rewrite attrs before an unknown mark is constructed as a fallback mark.
+    val unknownMarkAttrs: ((unknownMarkType: String, attrs: Attrs?) -> Attrs?)? = null
 )
 
 // A description of a node type, used when defining a schema.

--- a/model/src/commonTest/kotlin/com/atlassian/prosemirror/model/MarkTest.kt
+++ b/model/src/commonTest/kotlin/com/atlassian/prosemirror/model/MarkTest.kt
@@ -13,6 +13,7 @@ import com.atlassian.prosemirror.testbuilder.PMNodeBuilder.Companion.pos
 import com.atlassian.prosemirror.testbuilder.schema
 import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlinx.serialization.json.jsonObject
 
 val em_ = schema.mark("em")
 val strong = schema.mark("strong")
@@ -313,5 +314,36 @@ class MarkTest {
     @Test
     fun `excludes non-inclusive marks at a point where mark attrs change`() {
         assertThat(Mark.sameSet(customDoc.resolve(25).marks(), emptyList())).isTrue()
+    }
+
+    @Test
+    fun `applies unknown mark attrs to unsupported mark fallback`() {
+        val fallbackAttr = "fallbackAttr"
+        val unsupportedMarkSchema = Schema(
+            SchemaSpec(
+                nodes = mapOf(
+                    "doc" to NodeSpecImpl(content = "paragraph+"),
+                    "paragraph" to NodeSpecImpl(content = "text*"),
+                    "text" to NodeSpecImpl()
+                ),
+                marks = mapOf(
+                    "unsupportedMark" to MarkSpecImpl(
+                        attrs = mapOf(fallbackAttr to AttributeSpecImpl(default = null)),
+                        excludes = ""
+                    )
+                ),
+                unknownMarkAttrs = { unknownMarkType, attrs ->
+                    attrs.orEmpty() + (fallbackAttr to unknownMarkType)
+                }
+            )
+        )
+
+        val mark = Mark.fromJSON(
+            unsupportedMarkSchema,
+            com.atlassian.prosemirror.model.parser.JSON.parseToJsonElement("""{"type":"missing"}""").jsonObject
+        )
+
+        assertThat(mark.type.name).isEqualTo("unsupportedMark")
+        assertThat(mark.attrs[fallbackAttr]).isEqualTo("missing")
     }
 }

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-projectVersion=1.1.19
+projectVersion=1.1.20


### PR DESCRIPTION
Basically https://github.com/atlassian-labs/prosemirror-kotlin/pull/112 but for Marks. The existing solution does not work for documents with >1 unknown marks since they all use the instance of the UnsupportedMark, thus the original mark name information is lost.

`interface UnsupportedMark` is removed because it's not used here anymore, and removed the originalMarkName field writing (since mark instances should be immutable, just like nodes...).

Bump PM version to 1.1.20 for new release.